### PR TITLE
remove unused path dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-var path = require('path'),
-    isGlob = require('is-glob'),
+var isGlob = require('is-glob'),
 	_ = require('underscore.string');
 
 module.exports = function (string, options) {


### PR DESCRIPTION
Node "path" dependency is unused and causes browsers that use this package to throw an error. I'm hoping you can merge and make a 1.0.1 version in npm.